### PR TITLE
Uri angle sharp bug fix

### DIFF
--- a/BrowseSharp/Javascript/Javascript.cs
+++ b/BrowseSharp/Javascript/Javascript.cs
@@ -15,6 +15,7 @@ namespace BrowseSharp.Javascript
         public Javascript(IHtmlScriptElement scriptElement)
         {
             ScriptElement = scriptElement;
+            Content = scriptElement.Text;
         }
         
         /// <summary>
@@ -25,20 +26,12 @@ namespace BrowseSharp.Javascript
         /// <summary>
         /// Uri of script source
         /// </summary>
-        public Uri SourceUri
-        {
-            get { return !string.IsNullOrEmpty(ScriptElement.Source) ? new Uri(ScriptElement.Source) : null; }
-            set { ScriptElement.Source = value.AbsoluteUri; }
-        }
+        public Uri SourceUri { get; set; }
 
         /// <summary>
         /// Script content
         /// </summary>
-        public String Content
-        {
-            get { return ScriptElement != null ? ScriptElement.Text : ""; }
-            set { ScriptElement.Text = value; }
-        }
+        public String Content { get; set; }
         
         /// <summary>
         /// Same as script content, may be deprecated in the future, use Content instead

--- a/BrowseSharp/Toolbox/UriHelper.cs
+++ b/BrowseSharp/Toolbox/UriHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace BrowseSharp.Toolbox
 {
@@ -42,10 +43,9 @@ namespace BrowseSharp.Toolbox
                 scriptUri = new Uri(ConcatPath(responseUri.Scheme + "://" + responseUri.Host, scriptSource));
             else {
                 string scriptRelativePath = responseUri.Scheme + "://" + responseUri.Host;
-                for (int i = 0; i < responseUri.Segments.Length; i++)
+                int endSegments = String.IsNullOrWhiteSpace(Path.GetFileName(responseUri.LocalPath)) ? responseUri.Segments.Length : responseUri.Segments.Length - 1;
+                for (int i = 0; i < endSegments; i++)
                 {
-                    if (!responseUri.Segments[i].EndsWith("/"))
-                        break;
                     scriptRelativePath += responseUri.Segments[i];
                 }
                 scriptUri = new Uri(ConcatPath(scriptRelativePath,scriptSource));

--- a/BrowseSharp/Toolbox/UriHelper.cs
+++ b/BrowseSharp/Toolbox/UriHelper.cs
@@ -42,8 +42,10 @@ namespace BrowseSharp.Toolbox
                 scriptUri = new Uri(ConcatPath(responseUri.Scheme + "://" + responseUri.Host, scriptSource));
             else {
                 string scriptRelativePath = responseUri.Scheme + "://" + responseUri.Host;
-                for (int i = 0; i < responseUri.Segments.Length-1; i++)
+                for (int i = 0; i < responseUri.Segments.Length; i++)
                 {
+                    if (!responseUri.Segments[i].EndsWith("/"))
+                        break;
                     scriptRelativePath += responseUri.Segments[i];
                 }
                 scriptUri = new Uri(ConcatPath(scriptRelativePath,scriptSource));

--- a/BrowseSharpTest/UriHelper.Test.cs
+++ b/BrowseSharpTest/UriHelper.Test.cs
@@ -88,5 +88,12 @@ namespace BrowseSharpTest
             Uri uri = UriHelper.GetUri(new Uri("https://jayx239.github.io/BrowseSharpTest/"), "js/vendor/modernizr-3.6.0.min.js");
             Assert.AreEqual(uri.AbsoluteUri, "https://jayx239.github.io/BrowseSharpTest/js/vendor/modernizr-3.6.0.min.js");
         }
+
+        [Test]
+        public void TestParentDirectoyRelativeUri()
+        {
+            Uri uri = UriHelper.GetUri(new Uri("https://jayx239.github.io/BrowseSharpTest/"), "../js/vendor/modernizr-3.6.0.min.js");
+            Assert.AreEqual(uri.AbsoluteUri, "https://jayx239.github.io/js/vendor/modernizr-3.6.0.min.js");
+        }
     }
 }

--- a/BrowseSharpTest/UriHelper.Test.cs
+++ b/BrowseSharpTest/UriHelper.Test.cs
@@ -20,7 +20,7 @@ namespace BrowseSharpTest
             Uri result1 = UriHelper.GetUri(testUri, "/js/sass/");
             Assert.AreEqual(result1.AbsoluteUri, "https://google.com/js/sass/");
             Uri result2 = UriHelper.GetUri(testUri, "something/different");
-            Assert.AreEqual(result2.AbsoluteUri, "https://google.com/something/something/different");
+            Assert.AreEqual(result2.AbsoluteUri, "https://google.com/something/else/something/different");
             Uri result3 = UriHelper.GetUri(testUri, "https://amazon.com/something/different");
             Assert.AreEqual(result3.AbsoluteUri, "https://amazon.com/something/different");
             Uri result4 = UriHelper.GetUri(testUri, "www.amazon.com/something/different");
@@ -79,6 +79,14 @@ namespace BrowseSharpTest
             Uri browsesharpUri = UriHelper.Uri("www.browsesharp.com");
             Assert.IsTrue(browsesharpUri != null);
             Assert.AreEqual(browsesharpUri, new Uri("https://www.browsesharp.com"));
+        }
+
+        /* Bug fix release 0.0.8-beta */
+        [Test]
+        public void TestRelativeUri()
+        {
+            Uri uri = UriHelper.GetUri(new Uri("https://jayx239.github.io/BrowseSharpTest/"), "js/vendor/modernizr-3.6.0.min.js");
+            Assert.AreEqual(uri.AbsoluteUri, "https://jayx239.github.io/BrowseSharpTest/js/vendor/modernizr-3.6.0.min.js");
         }
     }
 }


### PR DESCRIPTION
## Pull Request

### Pull Request Purpose:
(b) Bug fix
#54 

### Describe briefly what changes are in the pull request and why they are relevant:
Fixed bug with UriHelper that would cause relative paths to be created incorrectly in some scenarios.
Decoupled Script and Style objects from AngleSharp objects so that BrowseSharp does not modify the content/uri of AngleSharp objects in these objects. The decoupling is important for future development with Dom manipulation and Javascript execution.